### PR TITLE
Support Debian Stretch

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,22 @@ Role Variables
 
 ufw_rules_allow_ports: []
 
+Add or remove rules:
+
+    ufw_rules_to_create: []
+    ufw_rules_to_delete: []
+
+Both `ufw_rules_to_create` and `ufw_rules_to_delete` accept a list of dictionaries, like so:
+
+    ufw_rules_to_create:
+      - direction: in
+        from_ip: 1.2.3.4
+        from_port: 5678
+        interface: eth0
+        proto: tcp
+        rule: allow
+        to_ip: 5.6.7.8
+        to_port: 1234
 
 Example Playbook
 -------------------------

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Example Playbook
 License
 -------
 
-LGPL.
+LGPL-3.0
 
 Author Information
 ------------------

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Requires the ufw firewall to be installed on the guest.
 Role Variables
 --------------
 
-ufw_rules_allow_ports: []
+Set the default policy:
+
+    ufw_rules_default_policy: deny
 
 Add or remove rules:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Install UWF (Uncomplicated Firewall)
 Requirements
 ------------
 
-Debian Wheezy/Jessie with the package python-pycurl and python-software-properties installed.
+Debian Wheezy/Jessie/Stretch with the package python-pycurl and python-software-properties installed.
 Requires the ufw firewall to be installed on the guest.
 
 Role Variables

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
 
+ufw_rules_default_policy: deny
+
 ufw_rules_to_create: []
 ufw_rules_to_delete: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 
-ufw_rules_allow_ports: []
+ufw_rules_to_create: []
+ufw_rules_to_delete: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,6 +10,7 @@ galaxy_info:
     versions:
       - wheezy
       - jessie
+      - stretch
   categories:
     - system
 dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Jasper N. Brouwer, Ramon de la Fuente"
   description: "Set UWF (Uncomplicated Firewall) rules"
   company: Future500
-  license: LGPL
+  license: LGPL-3.0
   min_ansible_version: 1.6
   platforms:
   - name: Debian

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,26 @@
 ---
 
-- name: set firewall allowed ports
-  ufw: "rule=allow port={{ item }}"
-  with_items: "{{ ufw_rules_allow_ports }}"
+- name: create rules
+  ufw:
+    direction: "{{ item.direction|default(omit) }}"
+    from_ip: "{{ item.from_ip|default(omit) }}"
+    from_port: "{{ item.from_port|default(omit) }}"
+    interface: "{{ item.interface|default(omit) }}"
+    proto: "{{ item.proto|default(omit) }}"
+    rule: "{{ item.rule|default('allow') }}"
+    to_ip: "{{ item.to_ip|default(omit) }}"
+    to_port: "{{ item.to_port|default(omit) }}"
+  with_items: "{{ ufw_rules_to_create }}"
+
+- name: delete rules
+  ufw:
+    direction: "{{ item.direction|default(omit) }}"
+    from_ip: "{{ item.from_ip|default(omit) }}"
+    from_port: "{{ item.from_port|default(omit) }}"
+    interface: "{{ item.interface|default(omit) }}"
+    proto: "{{ item.proto|default(omit) }}"
+    rule: "{{ item.rule|default('allow') }}"
+    to_ip: "{{ item.to_ip|default(omit) }}"
+    to_port: "{{ item.to_port|default(omit) }}"
+    delete: yes
+  with_items: "{{ ufw_rules_to_delete }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: set default policy
+  ufw:
+    policy: "{{ ufw_rules_default_policy }}"
+
 - name: create rules
   ufw:
     direction: "{{ item.direction|default(omit) }}"


### PR DESCRIPTION
Have a more flexible way to add (and remove) rules.
Add a variable to set the default policy (defaults to `deny`).
Add up to Stretch to supported Debian versions & Specify license version (LGPL-3.0).

After merge I recommend tagging `v3.0.0`.