### PR TITLE
Mark as deprecated (merged into f500.ufw)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
-Ufw
-========
+UFW Rules
+=========
 
-Install UWF (Uncomplicated Firewall)
+Create (or remove) UFW rules.
+
+Deprecated
+----------
+
+This role as been merged into [f500.ufw](https://github.com/f500/ansible-ufw) and is now deprecated.
+Please switch to `f500.ufw` version `4.0.0`.
 
 Requirements
 ------------
 
 Debian Wheezy/Jessie/Stretch with the package python-pycurl and python-software-properties installed.
-Requires the ufw firewall to be installed on the guest.
+Requires the UFW firewall to be installed on the guest.
 
 Role Variables
 --------------
@@ -38,16 +44,22 @@ Example Playbook
 
     - hosts: servers
       roles:
-         - { role: f500.ufw_rules, ufw_rules_allow_ports[22, 80, 443] }
+         - role: f500.ufw_rules
+           ufw_rules_to_create:
+             - { to_port: 22 }
+             - { to_port: 80 }
+             - { to_port: 443 }
 
 License
 -------
 
-LGPL-3.0
+Copyright (C) 2017 Future500 B.V.
+
+[LGPL-3.0](https://github.com/f500/ansible-ufw_rules/blob/master/COPYING.LESSER)
 
 Author Information
 ------------------
 
-Jasper N. Brouwer, jasper@nerdsweide.nl
+Jasper N. Brouwer, jasper@future500.nl
 
-Ramon de la Fuente, ramon@delafuente.nl
+Ramon de la Fuente, ramon@future500.nl

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,11 +6,11 @@ galaxy_info:
   license: LGPL-3.0
   min_ansible_version: 1.6
   platforms:
-  - name: Debian
-    versions:
-      - wheezy
-      - jessie
-      - stretch
-  categories:
+    - name: Debian
+      versions:
+        - wheezy
+        - jessie
+        - stretch
+  galaxy_tags:
     - system
-dependencies: []
+    - security


### PR DESCRIPTION
Update readme and meta.

Perhaps (after merging) we should tag it as `v3.0.3`, so the updated readme gets passed around.

See f500/ansible-ufw#5.